### PR TITLE
Document explicit task kinds and background stage semantics

### DIFF
--- a/book/src/ch05-task-graph.md
+++ b/book/src/ch05-task-graph.md
@@ -61,11 +61,15 @@ Each entry in the `tasks` array declares one task:
 (
     id: "src",                    // Unique string identifier
     type: "tasks::MySource",      // Rust type that implements the task
+    kind: source,                 // Optional but recommended: source | task | sink
 ),
 ```
 
 - **`id`** -- A unique name for this task instance. Used to reference it in connections.
 - **`type`** -- The fully qualified path to the Rust struct (relative to your crate root).
+- **`kind`** -- Declares whether the Rust type implements `CuSrcTask`, `CuTask`, or
+  `CuSinkTask`. Use `source`, `task`, or `sink`. Copper can still infer this for legacy
+  configs when the graph shape is unambiguous, but explicit `kind` is the preferred form.
 
 ### Optional task fields
 
@@ -98,9 +102,10 @@ Beyond `id` and `type`, each task entry supports several optional fields:
   ),
   ```
 
-- **`background`** -- When set to `true`, the task runs on a **background thread** instead
-  of the critical path. Useful for tasks that do heavy or blocking work (network I/O, disk
-  writes) that shouldn't affect the deterministic scheduling of other tasks.
+- **`background`** -- When set to `true`, a source or compatible task runs on a
+  **background thread** instead of the critical path. Useful for stages that do heavy or
+  blocking work (network I/O, disk writes) that shouldn't affect the deterministic
+  scheduling of other tasks.
 
   ```ron
   (
@@ -149,6 +154,10 @@ Each entry in `cnx` wires one task's output to another's input:
       missions: ["outdoor", "mapping"],
   ),
   ```
+
+If a source or regular task intentionally exposes an output that is unused in a given
+graph, point that connection at `dst: "__nc__"`. This keeps the output message type
+explicit without adding a dummy sink.
 
 ### How this compares to ROS
 

--- a/book/src/ch23-performance-basics.md
+++ b/book/src/ch23-performance-basics.md
@@ -109,7 +109,7 @@ This is the fast path for readers who already know what kind of bottleneck they 
 | `async-cl-io` | Moves CopperList serialization and logging to a dedicated thread | Task latencies are fine, but end-of-CL overhead is too high |
 | `parallel-rt` | Pipelines multiple CopperLists across generated process stages | Several CPU-bound stages are back to back and the global rate is too low |
 | `mmap-fsync` | Forces file `sync_all()` on section flush | The system runs fine for a while, then collapses under dirty-page / writeback pressure |
-| `background: true` | Runs one task on the background threadpool and returns `None` while it is still busy | One isolated task is too slow, but it does not need to block every cycle |
+| `background: true` | Runs one compatible source or task on the background threadpool and returns `None` while it is still busy | One isolated stage is too slow, but it does not need to block every cycle |
 | Task-local thread pool / parallel `for` | Parallelizes the internals of one task | One hot task has obvious internal data parallelism |
 | `logging: (enabled: false)` or `enable_task_logging: false` | Reduces logged bytes | Bandwidth and serialized size are too high |
 | `logging.copperlist_count` | Increases the number of preallocated in-flight CopperLists | Async or parallel modes stall because they run out of CopperList slots |
@@ -141,8 +141,9 @@ cargo run --features mmap-fsync
 `parallel-rt` is a **runtime-level pipeline**. Multiple CopperLists can be in flight at the
 same time, and each generated process stage keeps FIFO order for determinism.
 
-`background: true` is a **task-level escape hatch**. One task moves to the background
-threadpool and may return `None` for some cycles while its previous run is still finishing.
+`background: true` is a **stage-level escape hatch**. One source or task moves to the
+background threadpool and may return `None` for some cycles while its previous run is still
+finishing.
 
 ### `parallel-rt` is not the same as task-local parallelism
 
@@ -155,8 +156,8 @@ adding runtime-level parallelism around it.
 
 ## Background tasks and the threadpool bundle
 
-If a task is marked with `background: true`, Copper ensures a `threadpool` resource bundle is
+If a source or task is marked with `background: true`, Copper ensures a `threadpool` resource bundle is
 available. If you do not provide one explicitly, the runtime creates a default one.
 
-This makes background tasks easy to turn on, but it does not mean they are always the right
+This makes background stages easy to turn on, but it does not mean they are always the right
 choice. They work best when skipping or sampling intermediate cycles is acceptable.

--- a/book/src/ch25-troubleshooting-performance.md
+++ b/book/src/ch25-troubleshooting-performance.md
@@ -232,7 +232,7 @@ After enabling it, measure the cost. If the throughput penalty is too large:
 
 ## Background One Task
 
-Use this when **one isolated task** is too slow, but it does not need to block the whole loop.
+Use this when **one isolated source or task** is too slow, but it does not need to block the whole loop.
 
 ```ron
 (
@@ -244,7 +244,7 @@ Use this when **one isolated task** is too slow, but it does not need to block t
 
 What it means semantically:
 
-- Copper runs that task on the background threadpool
+- Copper runs that source or task on the background threadpool
 - while it is still busy, `process()` returns `None`
 - downstream tasks therefore see missing output for some cycles
 
@@ -268,7 +268,7 @@ Why:
 
 - the controller path usually needs one coherent output per cycle
 
-Copper will ensure a `threadpool` resource bundle exists when background tasks are present.
+Copper will ensure a `threadpool` resource bundle exists when background sources or tasks are present.
 If you need a specific sizing, provide that bundle explicitly instead of relying on the
 default.
 


### PR DESCRIPTION
Split out of gbin/tuning into a focused docs PR. This updates task graph docs to prefer explicit task kinds and aligns background-stage semantics in the performance chapters.