### PR TITLE
Fix GitHub link

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -10,7 +10,7 @@ build-dir = "output"
 [output.html]
 default-theme = "navy"
 preferred-dark-theme = "navy"
-git-repository-url = "https://github.com/NRdrgz/copper-rs-book"
+git-repository-url = "https://github.com/copper-project/copper-rs-book"
 site-url = "/copper-rs-book/"
 additional-css = ["theme/brand.css"]
 additional-js = ["theme/highlight-ron.js"]


### PR DESCRIPTION
Fix the git repo link appeared in the top right corner of the book